### PR TITLE
Use relative paths for stylesheet links

### DIFF
--- a/about.html
+++ b/about.html
@@ -13,7 +13,7 @@
 <meta property="og:image" content="/assets/img/og-cleanpro.png">
 <meta property="og:site_name" content="CleanPro">
 <link rel="icon" href="/assets/img/favicon.svg" type="image/svg+xml">
-<link rel="stylesheet" href="/assets/css/main.css">
+<link rel="stylesheet" href="assets/css/main.css">
 <script type="application/ld+json">
 {
   "@context": "https://schema.org",

--- a/contact.html
+++ b/contact.html
@@ -13,7 +13,7 @@
 <meta property="og:image" content="/assets/img/og-cleanpro.png">
 <meta property="og:site_name" content="CleanPro">
 <link rel="icon" href="/assets/img/favicon.svg" type="image/svg+xml">
-<link rel="stylesheet" href="/assets/css/main.css">
+<link rel="stylesheet" href="assets/css/main.css">
 <script type="application/ld+json">
 {
   "@context": "https://schema.org",

--- a/index.html
+++ b/index.html
@@ -13,7 +13,7 @@
 <meta property="og:image" content="/assets/img/og-cleanpro.png">
 <meta property="og:site_name" content="CleanPro">
 <link rel="icon" href="/assets/img/favicon.svg" type="image/svg+xml">
-<link rel="stylesheet" href="/assets/css/main.css">
+<link rel="stylesheet" href="assets/css/main.css">
 <script type="application/ld+json">
 {
   "@context": "https://schema.org",

--- a/packages.html
+++ b/packages.html
@@ -13,7 +13,7 @@
 <meta property="og:image" content="/assets/img/og-cleanpro.png">
 <meta property="og:site_name" content="CleanPro">
 <link rel="icon" href="/assets/img/favicon.svg" type="image/svg+xml">
-<link rel="stylesheet" href="/assets/css/main.css">
+<link rel="stylesheet" href="assets/css/main.css">
 <script type="application/ld+json">
 {
   "@context": "https://schema.org",

--- a/services.html
+++ b/services.html
@@ -13,7 +13,7 @@
 <meta property="og:image" content="/assets/img/og-cleanpro.png">
 <meta property="og:site_name" content="CleanPro">
 <link rel="icon" href="/assets/img/favicon.svg" type="image/svg+xml">
-<link rel="stylesheet" href="/assets/css/main.css">
+<link rel="stylesheet" href="assets/css/main.css">
 <script type="application/ld+json">
 {
   "@context": "https://schema.org",


### PR DESCRIPTION
## Summary
- switch each page to load the main stylesheet with a relative path so it works when served from subdirectories

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68ddb3b5855c832383432572d21b502c